### PR TITLE
Add test command to GitHub Actions

### DIFF
--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -7,15 +7,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      -
+        uses: actions/checkout@v1
+      -
+        uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-
-      - name: npm install, build, and test
-        run: |
-          npm ci
-          npm run build
-          npm run lint
+      -
+        name: install packages
+        run: npm ci
         env:
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: build
+        run: npm run build
+      -
+        name: lint
+        run: npm run lint
+      -
+        name: test
+        run: test

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -21,6 +21,8 @@ jobs:
       -
         name: build
         run: npm run build
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
         name: lint
         run: npm run lint

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       -
         uses: actions/checkout@v1
@@ -16,13 +19,9 @@ jobs:
       -
         name: install packages
         run: npm ci
-        env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
         name: build
         run: npm run build
-        env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
         name: lint
         run: npm run lint

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -27,4 +27,4 @@ jobs:
         run: npm run lint
       -
         name: test
-        run: test
+        run: npm test

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -11,20 +11,22 @@ jobs:
 
     steps:
       -
+        name: Checkout the branch
         uses: actions/checkout@v1
       -
+        name: Setup Node 12.x
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
       -
-        name: install packages
+        name: Install dependencies
         run: npm ci
       -
-        name: build
+        name: Check project builds
         run: npm run build
       -
-        name: lint
+        name: Check code quality
         run: npm run lint
       -
-        name: test
+        name: Run tests
         run: npm test

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       -
-        name: Checkout the branch
+        name: Checkout
         uses: actions/checkout@v1
       -
         name: Setup Node 12.x

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:json": "prettier --ignore-path .gitignore --check '**/*.json'",
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx src",
     "lint": "run-p lint:*",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.7",


### PR DESCRIPTION
Add `test` command as step in GitHub push action.

Changes single command to run over different steps to improve logs. Allows to know what step exactly fails: either `build`, `lint` or `test`.